### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Interested in participating in Hacktoberfest? We extend a warm invitation! You a
 
 
 # Announcement 🔊
-Climator is now a open-source project, and we welcome contributions. Information on how to get started can be found in our [contributor guide](CONTRIBUTING.md). 
+Climator is now an open-source project, and we welcome contributions. Information on how to get started can be found in our [contributor guide](CONTRIBUTING.md). 
 <br>
 
 ## Our Goal


### PR DESCRIPTION
Corrected the article to use 'an' instead of 'a' before 'open-source project' for proper grammar.

- [x] Documentation Update